### PR TITLE
Replace schemas' patternProperties with array for Satori form view compatibility.

### DIFF
--- a/definitions/04-Hiro-Tutorials.json
+++ b/definitions/04-Hiro-Tutorials.json
@@ -1,23 +1,37 @@
 {
-    "tutorials": {
-        "id1": {
-            "start_step": 0,
-            "max_step": 10,
-            "additional_properties": {
-                "key1": "value1"
+    "tutorials": [
+        {
+            "key": "id1",
+            "value": {
+                "start_step": 0,
+                "max_step": 10,
+                "additional_properties": [
+                    {
+                        "key": "key1",
+                        "value": "value1"
+                    }
+                ]
             }
         },
-        "id2": {
-            "start_step": 0,
-            "max_step": 15,
-            "additional_properties": {
-                "key2": "value2",
-                "key3": "value3"
+        {
+            "key": "id2",
+            "value": {
+                "start_step": 0,
+                "max_step": 15,
+                "additional_properties": [
+                    {
+                        "key": "key2",
+                        "value": "value2"
+                    }
+                ]
             }
         },
-        "id3": {
-            "start_step": 0,
-            "max_step": 15
+        {
+            "key": "id3",
+            "value": {
+                "start_step": 0,
+                "max_step": 15
+            }
         }
-    }
+    ]
 }

--- a/definitions/_01-Hiro-Reward.json
+++ b/definitions/_01-Hiro-Reward.json
@@ -1,69 +1,4 @@
 {
-  "items": {
-    "item1": {
-      "min": 2,
-      "max": 2,
-      "multiple": 1
-    },
-    "item2": {
-      "min": 10,
-      "max": 100,
-      "multiple": 5
-    }
-  },
-  "item_sets": [
-    {
-      "min": 1,
-      "max": 10,
-      "multiple": 1,
-      "max_repeats": 0,
-      "set": [ "set1", "set2" ]
-    }
-  ],
-  "currencies": {
-    "currency1": {
-      "min": 1,
-      "max": 10,
-      "multiple": 1
-    },
-    "currency2": {
-      "min": 10,
-      "max": 100,
-      "multiple": 5
-    }
-  },
-  "energies": {
-    "energy1": {
-      "min": 1,
-      "max": 10,
-      "multiple": 1
-    },
-    "energy2": {
-      "min": 10,
-      "max": 100,
-      "multiple": 5
-    }
-  },
-  "energy_modifiers": [
-    {
-      "id": "id1",
-      "operator": "infinite",
-      "duration_sec": {
-        "min": 30,
-        "max": 60,
-        "multiple": 5
-      }
-    },
-    {
-      "id": "id2",
-      "operator": "infinite",
-      "duration_sec": {
-        "min": 1,
-        "max": 10,
-        "multiple": 1
-      }
-    }
-  ],
   "reward_modifiers": [
     {
       "id": "id1",
@@ -79,20 +14,91 @@
         "max": 60,
         "multiple": 5
       }
+    }
+  ],
+  "items": [
+    {
+      "key": "item1",
+      "value": {
+        "max": 2,
+        "min": 2,
+        "multiple": 1
+      }
+    },
+    {
+      "key": "item2",
+      "value": {
+        "max": 100,
+        "min": 10,
+        "multiple": 5
+      }
+    }
+  ],
+  "item_sets": [
+    {
+      "min": 1,
+      "max": 10,
+      "multiple": 1,
+      "max_repeats": 0,
+      "set": [
+        "set1",
+        "set2"
+      ]
+    }
+  ],
+  "currencies": [
+    {
+      "key": "currency1",
+      "value": {
+        "max": 10,
+        "min": 1,
+        "multiple": 1
+      }
+    },
+    {
+      "key": "currency2",
+      "value": {
+        "max": 100,
+        "min": 10,
+        "multiple": 5
+      }
+    }
+  ],
+  "energies": [
+    {
+      "key": "energy1",
+      "value": {
+        "max": 10,
+        "min": 1,
+        "multiple": 1
+      }
+    },
+    {
+      "key": "energy2",
+      "value": {
+        "max": 100,
+        "min": 10,
+        "multiple": 5
+      }
+    }
+  ],
+  "energy_modifiers": [
+    {
+      "id": "id1",
+      "operator": "infinite",
+      "duration_sec": {
+        "max": 60,
+        "min": 30,
+        "multiple": 5
+      }
     },
     {
       "id": "id2",
-      "type": "item",
-      "operator": "addition",
-      "value": {
-        "min": 10,
-        "max": 50,
-        "multiple": 10
-      },
+      "operator": "infinite",
       "duration_sec": {
-        "min": 30,
-        "max": 60,
-        "multiple": 5
+        "min": 1,
+        "max": 10,
+        "multiple": 1
       }
     }
   ],

--- a/definitions/_02-Hiro-Rewards.json
+++ b/definitions/_02-Hiro-Rewards.json
@@ -1,26 +1,35 @@
 {
   "guaranteed": {
-    "items": {
-      "item1": {
-        "min": 2,
-        "max": 2,
-        "multiple": 1
+    "items": [
+      {
+        "key": "item1",
+        "value": {
+          "max": 2,
+          "min": 2,
+          "multiple": 1
+        }
       },
-      "item2": {
-        "min": 10,
-        "max": 100,
-        "multiple": 5
+      {
+        "key": "item2",
+        "value": {
+          "max": 100,
+          "min": 10,
+          "multiple": 5
+        }
       }
-    }
+    ]
   },
   "weighted": [
     {
-      "currencies": {
-        "currency1": {
-          "min": 100,
-          "max": 200
+      "currencies": [
+        {
+          "key": "currency1",
+          "value": {
+            "max": 200,
+            "min": 100
+          }
         }
-      },
+      ],
       "weight": 5
     }
   ],

--- a/schemas/01-Hiro-Reward.json
+++ b/schemas/01-Hiro-Reward.json
@@ -2,66 +2,88 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "properties": {
     "currencies": {
-      "patternProperties": {
-        ".{1,}": {
-          "properties": {
-            "max": {
-              "minimum": 0,
-              "title": "max",
-              "type": "number"
-            },
-            "min": {
-              "minimum": 0,
-              "title": "min",
-              "type": "number"
-            },
-            "multiple": {
-              "minimum": 0,
-              "title": "multiple",
-              "type": "number"
-            }
+      "items": {
+        "properties": {
+          "key": {
+            "pattern": ".{1,}",
+            "type": "string"
           },
-          "required": [
-            "min",
-            "max"
-          ],
-          "title": "id",
-          "type": "object"
-        }
+          "value": {
+            "properties": {
+              "max": {
+                "minimum": 0,
+                "title": "max",
+                "type": "number"
+              },
+              "min": {
+                "minimum": 0,
+                "title": "min",
+                "type": "number"
+              },
+              "multiple": {
+                "minimum": 0,
+                "title": "multiple",
+                "type": "number"
+              }
+            },
+            "required": [
+              "min",
+              "max"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "title": "id",
+        "type": "object"
       },
       "title": "currencies",
-      "type": "object"
+      "type": "array"
     },
     "energies": {
-      "patternProperties": {
-        ".{1,}": {
-          "properties": {
-            "max": {
-              "minimum": 0,
-              "title": "max",
-              "type": "number"
-            },
-            "min": {
-              "minimum": 0,
-              "title": "min",
-              "type": "number"
-            },
-            "multiple": {
-              "minimum": 0,
-              "title": "multiple",
-              "type": "number"
-            }
+      "items": {
+        "properties": {
+          "key": {
+            "pattern": ".{1,}",
+            "type": "string"
           },
-          "required": [
-            "min",
-            "max"
-          ],
-          "title": "id",
-          "type": "object"
-        }
+          "value": {
+            "properties": {
+              "max": {
+                "minimum": 0,
+                "title": "max",
+                "type": "number"
+              },
+              "min": {
+                "minimum": 0,
+                "title": "min",
+                "type": "number"
+              },
+              "multiple": {
+                "minimum": 0,
+                "title": "multiple",
+                "type": "number"
+              }
+            },
+            "required": [
+              "min",
+              "max"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "title": "id",
+        "type": "object"
       },
       "title": "energies",
-      "type": "object"
+      "type": "array"
     },
     "energy_modifiers": {
       "items": {
@@ -156,35 +178,46 @@
       "type": "array"
     },
     "items": {
-      "patternProperties": {
-        ".{1,}": {
-          "properties": {
-            "max": {
-              "minimum": 0,
-              "title": "max",
-              "type": "number"
-            },
-            "min": {
-              "minimum": 0,
-              "title": "min",
-              "type": "number"
-            },
-            "multiple": {
-              "minimum": 0,
-              "title": "multiple",
-              "type": "number"
-            }
+      "items": {
+        "properties": {
+          "key": {
+            "pattern": ".{1,}",
+            "type": "string"
           },
-          "required": [
-            "min",
-            "max"
-          ],
-          "title": "id",
-          "type": "object"
-        }
+          "value": {
+            "properties": {
+              "max": {
+                "minimum": 0,
+                "title": "max",
+                "type": "number"
+              },
+              "min": {
+                "minimum": 0,
+                "title": "min",
+                "type": "number"
+              },
+              "multiple": {
+                "minimum": 0,
+                "title": "multiple",
+                "type": "number"
+              }
+            },
+            "required": [
+              "min",
+              "max"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "title": "id",
+        "type": "object"
       },
       "title": "items",
-      "type": "object"
+      "type": "array"
     },
     "reward_modifiers": {
       "items": {

--- a/schemas/04-Hiro-Tutorials.json
+++ b/schemas/04-Hiro-Tutorials.json
@@ -1,41 +1,51 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
   "properties": {
     "tutorials": {
-      "patternProperties": {
-        ".{1,}": {
-          "properties": {
-            "additional_properties": {
-              "patternProperties": {
-                ".{1,}": {
-                  "title": "key",
-                  "type": "string"
-                }
-              },
-              "title": "additional_properties",
-              "type": "object"
-            },
-            "max_step": {
-              "minimum": 0,
-              "title": "max_step",
-              "type": "number"
-            },
-            "start_step": {
-              "minimum": 0,
-              "title": "start_step",
-              "type": "number"
-            }
-          },
-          "title": "id",
-          "type": "object"
-        }
-      },
+      "type": "array",
       "title": "tutorials",
-      "type": "object"
+      "items": {
+        "title": "id",
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "pattern": ".{1,}"
+          },
+          "value": {
+            "type": "object",
+            "properties": {
+              "max_step": {
+                "title": "max_step",
+                "type": "number",
+                "minimum": 0
+              },
+              "start_step": {
+                "title": "start_step",
+                "type": "number",
+                "minimum": 0
+              },
+              "additional_properties": {
+                "type": "array",
+                "title": "additional_properties",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string",
+                      "pattern": ".{1,}"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
-  },
-  "required": [
-    "tutorials"
-  ],
-  "type": "object"
+  }
 }


### PR DESCRIPTION
Syntax is valid, but dynamic form builder libraries will not build items for 'optional' matching syntax like `patternProperties`.