### PR TITLE
Add switches for core and authenticate events to be sent by the Satori Personalizer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 :warning: This server code is versioned separately to the download of the [Hiro game framework](https://heroiclabs.com/hiro/). :warning:
 
 ## [Unreleased]
+### Added
+- Add switches for core and authenticate events to be sent by the SatoriPersonalizer.
+
 ### Changed
 - Update nakama-common to v1.30.0 release.
 

--- a/personalizer.go
+++ b/personalizer.go
@@ -31,8 +31,8 @@ type Personalizer interface {
 var _ Personalizer = &SatoriPersonalizer{}
 
 type SatoriPersonalizer struct {
-	publishAuthenticateEvent bool
-	publishCoreEvents        bool
+	publishAuthenticateRequest bool
+	publishCoreEvents          bool
 }
 
 func (p *SatoriPersonalizer) GetValue(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, system System, userID string) (any, error) {
@@ -88,8 +88,8 @@ func (p *SatoriPersonalizer) GetValue(ctx context.Context, logger runtime.Logger
 	return config, nil
 }
 
-func (p *SatoriPersonalizer) IsPublishAuthenticateEvent() bool {
-	return p.publishAuthenticateEvent
+func (p *SatoriPersonalizer) IsPublishAuthenticateRequest() bool {
+	return p.publishAuthenticateRequest
 }
 
 func (p *SatoriPersonalizer) IsPublishCoreEvents() bool {
@@ -98,7 +98,7 @@ func (p *SatoriPersonalizer) IsPublishCoreEvents() bool {
 
 func NewSatoriPersonalizer(publishAuthenticateEvent, publishCoreEvents bool) *SatoriPersonalizer {
 	return &SatoriPersonalizer{
-		publishAuthenticateEvent: publishAuthenticateEvent,
-		publishCoreEvents:        publishCoreEvents,
+		publishAuthenticateRequest: publishAuthenticateEvent,
+		publishCoreEvents:          publishCoreEvents,
 	}
 }

--- a/personalizer.go
+++ b/personalizer.go
@@ -31,6 +31,8 @@ type Personalizer interface {
 var _ Personalizer = &SatoriPersonalizer{}
 
 type SatoriPersonalizer struct {
+	publishAuthenticateEvent bool
+	publishCoreEvents        bool
 }
 
 func (p *SatoriPersonalizer) GetValue(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, system System, userID string) (any, error) {
@@ -84,4 +86,19 @@ func (p *SatoriPersonalizer) GetValue(ctx context.Context, logger runtime.Logger
 	}
 
 	return config, nil
+}
+
+func (p *SatoriPersonalizer) IsPublishAuthenticateEvent() bool {
+	return p.publishAuthenticateEvent
+}
+
+func (p *SatoriPersonalizer) IsPublishCoreEvents() bool {
+	return p.publishCoreEvents
+}
+
+func NewSatoriPersonalizer(publishAuthenticateEvent, publishCoreEvents bool) *SatoriPersonalizer {
+	return &SatoriPersonalizer{
+		publishAuthenticateEvent: publishAuthenticateEvent,
+		publishCoreEvents:        publishCoreEvents,
+	}
 }


### PR DESCRIPTION
This allows the use of the `SatoriPersonalizer` to optionally have Hiro send authenticate requests or core analytics events which are server sent. i.e.

```go
systems.SetPersonalizer(hiro.NewSatoriPersonalizer(true, true))
```
