### PR TITLE
Update schema validator templates

### DIFF
--- a/definitions/13-Hiro-Incentives.json
+++ b/definitions/13-Hiro-Incentives.json
@@ -1,14 +1,14 @@
 {
-    "incentives": {
-        "incentive1": {
-            "type": 1,
-            "name": "Incentive One",
-            "description": "Description of the first incentive",
-            "max_claims": 100,
-            "max_global_claims": 500,
-            "max_recipient_age_sec": 3600,
-            "max_concurrent": 10,
-            "expiry_duration_sec": 86400
-        }
+  "incentives": {
+    "incentive1": {
+      "type": 1,
+      "name": "Incentive One",
+      "description": "Description of the first incentive",
+      "max_claims": 100,
+      "max_global_claims": 500,
+      "max_recipient_age_sec": 3600,
+      "max_concurrent": 10,
+      "expiry_duration_sec": 86400
     }
+  }
 }

--- a/definitions/13-Hiro-Incentives.json
+++ b/definitions/13-Hiro-Incentives.json
@@ -1,0 +1,14 @@
+{
+    "incentives": {
+        "incentive1": {
+            "type": 1,
+            "name": "Incentive One",
+            "description": "Description of the first incentive",
+            "max_claims": 100,
+            "max_global_claims": 500,
+            "max_recipient_age_sec": 3600,
+            "max_concurrent": 10,
+            "expiry_duration_sec": 86400
+        }
+    }
+}

--- a/definitions/14-Hiro-Progressions.json
+++ b/definitions/14-Hiro-Progressions.json
@@ -1,0 +1,60 @@
+{
+    "progressions": {
+        "progression1": {
+            "name": "First Progression",
+            "description": "Description of the first progression",
+            "category": "category1",
+            "additional_properties": {
+                "propKey1": "propValue1",
+                "propKey2": "propValue2"
+            },
+            "preconditions": {
+                "direct": {
+                    "counts": {
+                        "countKey1": 5,
+                        "countKey2": 10
+                    },
+                    "cost": {
+                        "items": {
+                            "item1": 2,
+                            "item2": 3
+                        },
+                        "currencies": {
+                            "currency1": 100,
+                            "currency2": 200
+                        }
+                    },
+                    "achievements": [
+                        "achievement1",
+                        "achievement2"
+                    ],
+                    "items_min": {
+                        "item1": 1,
+                        "item2": 2
+                    }
+                },
+                "operator": 1
+            }
+        },
+        "progression2": {
+            "name": "Second Progression",
+            "description": "Description of the second progression",
+            "category": "category2",
+            "additional_properties": {
+                "propKey3": "propValue3"
+            }
+        },
+        "progression3": {
+            "name": "Third Progression",
+            "description": "Description of the third progression",
+            "category": "category3",
+            "preconditions": {
+                "direct": {
+                    "progressions": [
+                        "progression2"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/definitions/14-Hiro-Progressions.json
+++ b/definitions/14-Hiro-Progressions.json
@@ -1,60 +1,60 @@
 {
-    "progressions": {
-        "progression1": {
-            "name": "First Progression",
-            "description": "Description of the first progression",
-            "category": "category1",
-            "additional_properties": {
-                "propKey1": "propValue1",
-                "propKey2": "propValue2"
+  "progressions": {
+    "progression1": {
+      "name": "First Progression",
+      "description": "Description of the first progression",
+      "category": "category1",
+      "additional_properties": {
+        "propKey1": "propValue1",
+        "propKey2": "propValue2"
+      },
+      "preconditions": {
+        "direct": {
+          "counts": {
+            "countKey1": 5,
+            "countKey2": 10
+          },
+          "cost": {
+            "items": {
+              "item1": 2,
+              "item2": 3
             },
-            "preconditions": {
-                "direct": {
-                    "counts": {
-                        "countKey1": 5,
-                        "countKey2": 10
-                    },
-                    "cost": {
-                        "items": {
-                            "item1": 2,
-                            "item2": 3
-                        },
-                        "currencies": {
-                            "currency1": 100,
-                            "currency2": 200
-                        }
-                    },
-                    "achievements": [
-                        "achievement1",
-                        "achievement2"
-                    ],
-                    "items_min": {
-                        "item1": 1,
-                        "item2": 2
-                    }
-                },
-                "operator": 1
+            "currencies": {
+              "currency1": 100,
+              "currency2": 200
             }
+          },
+          "achievements": [
+            "achievement1",
+            "achievement2"
+          ],
+          "items_min": {
+            "item1": 1,
+            "item2": 2
+          }
         },
-        "progression2": {
-            "name": "Second Progression",
-            "description": "Description of the second progression",
-            "category": "category2",
-            "additional_properties": {
-                "propKey3": "propValue3"
-            }
-        },
-        "progression3": {
-            "name": "Third Progression",
-            "description": "Description of the third progression",
-            "category": "category3",
-            "preconditions": {
-                "direct": {
-                    "progressions": [
-                        "progression2"
-                    ]
-                }
-            }
+        "operator": 1
+      }
+    },
+    "progression2": {
+      "name": "Second Progression",
+      "description": "Description of the second progression",
+      "category": "category2",
+      "additional_properties": {
+        "propKey3": "propValue3"
+      }
+    },
+    "progression3": {
+      "name": "Third Progression",
+      "description": "Description of the third progression",
+      "category": "category3",
+      "preconditions": {
+        "direct": {
+          "progressions": [
+            "progression2"
+          ]
         }
+      }
     }
+  }
 }

--- a/definitions/15-Hiro-Stats.json
+++ b/definitions/15-Hiro-Stats.json
@@ -1,9 +1,9 @@
 {
-    "whitelist": [
-      "strength",
-      "constitution",
-      "dexterity",
-      "wisdom",
-      "intellect"
-    ]
+  "whitelist": [
+    "strength",
+    "constitution",
+    "dexterity",
+    "wisdom",
+    "intellect"
+  ]
 }

--- a/definitions/15-Hiro-Stats.json
+++ b/definitions/15-Hiro-Stats.json
@@ -1,0 +1,9 @@
+{
+    "whitelist": [
+      "strength",
+      "constitution",
+      "dexterity",
+      "wisdom",
+      "intellect"
+    ]
+}

--- a/schemas/08-Hiro-Energy.json
+++ b/schemas/08-Hiro-Energy.json
@@ -24,6 +24,11 @@
               "title": "max_count",
               "type": "number"
             },
+            "max_overfill": {
+              "minimum": 0,
+              "title": "max_overfill",
+              "type": "number"
+            },
             "refill_count": {
               "minimum": 0,
               "title": "refill_count",

--- a/schemas/12-Hiro-Event-Leaderboards.json
+++ b/schemas/12-Hiro-Event-Leaderboards.json
@@ -154,6 +154,8 @@
       }
     }
   },
-  "required": ["event_leaderboards"],
+  "required": [
+    "event_leaderboards"
+  ],
   "type": "object"
 }

--- a/schemas/12-Hiro-Event-Leaderboards.json
+++ b/schemas/12-Hiro-Event-Leaderboards.json
@@ -121,6 +121,10 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "name": {
+                        "type": "string",
+                        "title": "name"
+                      },
                       "rank_min": {
                         "type": "number",
                         "title": "rank_min",

--- a/schemas/13-Hiro-Incentives.json
+++ b/schemas/13-Hiro-Incentives.json
@@ -1,64 +1,77 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-      "incentives": {
-        "type": "object",
-        "patternProperties": {
-          ".{1,}": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "integer",
-                "minimum": 0,
-                "title": "type"
-              },
-              "name": {
-                "type": "string",
-                "title": "name"
-              },
-              "description": {
-                "type": "string",
-                "title": "description"
-              },
-              "max_claims": {
-                "type": "integer",
-                "minimum": 0,
-                "title": "max_claims"
-              },
-              "max_global_claims": {
-                "type": "integer",
-                "minimum": 0,
-                "title": "max_global_claims"
-              },
-              "max_recipient_age_sec": {
-                "type": "integer",
-                "minimum": 0,
-                "title": "max_recipient_age_sec"
-              },
-              "recipient_reward": {
-                "$ref": "Hiro-Rewards",
-                "title": "recipient_reward"
-              },
-              "sender_reward": {
-                "$ref": "Hiro-Rewards",
-                "title": "sender_reward"
-              },
-              "max_concurrent": {
-                "type": "integer",
-                "minimum": 0,
-                "title": "max_concurrent"
-              },
-              "expiry_duration_sec": {
-                "type": "integer",
-                "minimum": 0,
-                "title": "expiry_duration_sec"
-              }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "incentives": {
+      "type": "object",
+      "patternProperties": {
+        ".{1,}": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "type"
             },
-            "required": ["type", "name", "description", "max_claims", "max_global_claims", "max_recipient_age_sec", "recipient_reward", "sender_reward", "max_concurrent", "expiry_duration_sec"]
-          }
-        },
-        "title": "incentives"
-      }
-    },
-    "required": ["incentives"]
-  }
+            "name": {
+              "type": "string",
+              "title": "name"
+            },
+            "description": {
+              "type": "string",
+              "title": "description"
+            },
+            "max_claims": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "max_claims"
+            },
+            "max_global_claims": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "max_global_claims"
+            },
+            "max_recipient_age_sec": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "max_recipient_age_sec"
+            },
+            "recipient_reward": {
+              "$ref": "Hiro-Rewards",
+              "title": "recipient_reward"
+            },
+            "sender_reward": {
+              "$ref": "Hiro-Rewards",
+              "title": "sender_reward"
+            },
+            "max_concurrent": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "max_concurrent"
+            },
+            "expiry_duration_sec": {
+              "type": "integer",
+              "minimum": 0,
+              "title": "expiry_duration_sec"
+            }
+          },
+          "required": [
+            "type",
+            "name",
+            "description",
+            "max_claims",
+            "max_global_claims",
+            "max_recipient_age_sec",
+            "recipient_reward",
+            "sender_reward",
+            "max_concurrent",
+            "expiry_duration_sec"
+          ]
+        }
+      },
+      "title": "incentives"
+    }
+  },
+  "required": [
+    "incentives"
+  ]
+}

--- a/schemas/13-Hiro-Incentives.json
+++ b/schemas/13-Hiro-Incentives.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "incentives": {
+        "type": "object",
+        "patternProperties": {
+          ".{1,}": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "type"
+              },
+              "name": {
+                "type": "string",
+                "title": "name"
+              },
+              "description": {
+                "type": "string",
+                "title": "description"
+              },
+              "max_claims": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "max_claims"
+              },
+              "max_global_claims": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "max_global_claims"
+              },
+              "max_recipient_age_sec": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "max_recipient_age_sec"
+              },
+              "recipient_reward": {
+                "$ref": "Hiro-Rewards",
+                "title": "recipient_reward"
+              },
+              "sender_reward": {
+                "$ref": "Hiro-Rewards",
+                "title": "sender_reward"
+              },
+              "max_concurrent": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "max_concurrent"
+              },
+              "expiry_duration_sec": {
+                "type": "integer",
+                "minimum": 0,
+                "title": "expiry_duration_sec"
+              }
+            },
+            "required": ["type", "name", "description", "max_claims", "max_global_claims", "max_recipient_age_sec", "recipient_reward", "sender_reward", "max_concurrent", "expiry_duration_sec"]
+          }
+        },
+        "title": "incentives"
+      }
+    },
+    "required": ["incentives"]
+  }

--- a/schemas/13-Hiro-Incentives.json
+++ b/schemas/13-Hiro-Incentives.json
@@ -57,13 +57,8 @@
           "required": [
             "type",
             "name",
-            "description",
             "max_claims",
             "max_global_claims",
-            "max_recipient_age_sec",
-            "recipient_reward",
-            "sender_reward",
-            "max_concurrent",
             "expiry_duration_sec"
           ]
         }

--- a/schemas/14-Hiro-Progressions.json
+++ b/schemas/14-Hiro-Progressions.json
@@ -1,163 +1,163 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-        "progressions": {
-            "type": "object",
-            "patternProperties": {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "progressions": {
+      "type": "object",
+      "patternProperties": {
+        ".{1,}": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "category": {
+              "type": "string"
+            },
+            "additional_properties": {
+              "type": "object",
+              "patternProperties": {
                 ".{1,}": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "description": {
-                            "type": "string"
-                        },
-                        "category": {
-                            "type": "string"
-                        },
-                        "additional_properties": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".{1,}": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "preconditions": {
-                            "$ref": "#/definitions/ProgressionPreconditionsBlock"
-                        }
-                    },
-                    "required": []
+                  "type": "string"
                 }
+              }
+            },
+            "preconditions": {
+              "$ref": "#/definitions/ProgressionPreconditionsBlock"
             }
+          },
+          "required": []
         }
-    },
-    "required": [
-        "progressions"
-    ],
-    "definitions": {
-        "ProgressionPreconditionsBlock": {
-            "type": "object",
-            "properties": {
-                "direct": {
-                    "type": "object",
-                    "properties": {
-                        "counts": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".{1,}": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "cost": {
-                            "type": "object",
-                            "properties": {
-                                "items": {
-                                    "type": "object",
-                                    "patternProperties": {
-                                        ".{1,}": {
-                                            "type": "integer"
-                                        }
-                                    }
-                                },
-                                "currencies": {
-                                    "type": "object",
-                                    "patternProperties": {
-                                        ".{1,}": {
-                                            "type": "integer"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "progressions": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "achievements": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "items_min": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".{1,}": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "items_max": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".{1,}": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "stats_min": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".{1,}": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "stats_max": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".{1,}": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "energy_min": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".{1,}": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "energy_max": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".{1,}": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "currency_min": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".{1,}": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "currency_max": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".{1,}": {
-                                    "type": "integer"
-                                }
-                            }
-                        }
-                    }
-                },
-                "operator": {
-                    "type": "integer",
-                    "minimum": 0
-                },
-                "nested": {
-                    "$ref": "#/definitions/ProgressionPreconditionsBlock"
-                }
-            }
-        }
+      }
     }
+  },
+  "required": [
+    "progressions"
+  ],
+  "definitions": {
+    "ProgressionPreconditionsBlock": {
+      "type": "object",
+      "properties": {
+        "direct": {
+          "type": "object",
+          "properties": {
+            "counts": {
+              "type": "object",
+              "patternProperties": {
+                ".{1,}": {
+                  "type": "integer"
+                }
+              }
+            },
+            "cost": {
+              "type": "object",
+              "properties": {
+                "items": {
+                  "type": "object",
+                  "patternProperties": {
+                    ".{1,}": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "currencies": {
+                  "type": "object",
+                  "patternProperties": {
+                    ".{1,}": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            },
+            "progressions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "achievements": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "items_min": {
+              "type": "object",
+              "patternProperties": {
+                ".{1,}": {
+                  "type": "integer"
+                }
+              }
+            },
+            "items_max": {
+              "type": "object",
+              "patternProperties": {
+                ".{1,}": {
+                  "type": "integer"
+                }
+              }
+            },
+            "stats_min": {
+              "type": "object",
+              "patternProperties": {
+                ".{1,}": {
+                  "type": "integer"
+                }
+              }
+            },
+            "stats_max": {
+              "type": "object",
+              "patternProperties": {
+                ".{1,}": {
+                  "type": "integer"
+                }
+              }
+            },
+            "energy_min": {
+              "type": "object",
+              "patternProperties": {
+                ".{1,}": {
+                  "type": "integer"
+                }
+              }
+            },
+            "energy_max": {
+              "type": "object",
+              "patternProperties": {
+                ".{1,}": {
+                  "type": "integer"
+                }
+              }
+            },
+            "currency_min": {
+              "type": "object",
+              "patternProperties": {
+                ".{1,}": {
+                  "type": "integer"
+                }
+              }
+            },
+            "currency_max": {
+              "type": "object",
+              "patternProperties": {
+                ".{1,}": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "operator": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "nested": {
+          "$ref": "#/definitions/ProgressionPreconditionsBlock"
+        }
+      }
+    }
+  }
 }

--- a/schemas/14-Hiro-Progressions.json
+++ b/schemas/14-Hiro-Progressions.json
@@ -1,0 +1,164 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "progressions": {
+            "type": "object",
+            "patternProperties": {
+                ".{1,}": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "category": {
+                            "type": "string"
+                        },
+                        "additional_properties": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".{1,}": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "preconditions": {
+                            "$ref": "#/definitions/ProgressionPreconditionsBlock"
+                        }
+                    },
+                    "required": []
+                }
+            }
+        }
+    },
+    "required": [
+        "progressions"
+    ],
+    "definitions": {
+        "ProgressionPreconditionsBlock": {
+            "type": "object",
+            "properties": {
+                "direct": {
+                    "type": "object",
+                    "properties": {
+                        "counts": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".{1,}": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "cost": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "object",
+                                    "patternProperties": {
+                                        ".{1,}": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "currencies": {
+                                    "type": "object",
+                                    "patternProperties": {
+                                        ".{1,}": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "progressions": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "achievements": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "items_min": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".{1,}": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "items_max": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".{1,}": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "stats_min": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".{1,}": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "stats_max": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".{1,}": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "energy_min": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".{1,}": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "energy_max": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".{1,}": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "currency_min": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".{1,}": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "currency_max": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".{1,}": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "operator": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "nested": {
+                    "$ref": "#/definitions/ProgressionPreconditionsBlock"
+                }
+            }
+        }
+    }
+}

--- a/schemas/14-Hiro-Progressions.json
+++ b/schemas/14-Hiro-Progressions.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
     "properties": {
         "progressions": {
             "type": "object",

--- a/schemas/15-Hiro-Stats.json
+++ b/schemas/15-Hiro-Stats.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "whitelist": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": ["whitelist"]
+  }

--- a/schemas/15-Hiro-Stats.json
+++ b/schemas/15-Hiro-Stats.json
@@ -1,12 +1,14 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-      "whitelist": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "whitelist": {
+      "type": "array",
+      "items": {
+        "type": "string"
       }
-    },
-    "required": ["whitelist"]
-  }
+    }
+  },
+  "required": [
+    "whitelist"
+  ]
+}


### PR DESCRIPTION
- Added schemas for stats, incentives and progressions.
- Minor updates to energy and event leaderboards.
- Also added more examples to the definitions folder.

- [x] Need to verify that this is the correct JSON field name `"-"` and if so I'll add it to the unlockables schema
https://github.com/heroiclabs/hiro/commit/e3c4eb778f54758c16ff4a50c530cc83a24b681b#diff-bccc16b359e387cd48e76123fe40c0d20cdef0996615ddebd9fe31717a195ef7R30

- [x] Need to verify what properties should be marked as required for incentives. I made all of them required for now but couldn't really grok what should or shouldn't be from looking at the incentives code @zyro 

