### PR TITLE
move incentives below rewards

### DIFF
--- a/hiro.proto
+++ b/hiro.proto
@@ -158,122 +158,6 @@ enum RpcId {
   RPC_ID_ECONOMY_PLACEMENT_FAIL = 1002;
 }
 
-// Types of incentives.
-enum IncentiveType {
-  // Unspecified. Defaults to INVITE.
-  INCENTIVE_TYPE_UNSPECIFIED = 0;
-  // An invite with an associated incentive reward.
-  INCENTIVE_TYPE_INVITE = 1;
-}
-
-// The result of claiming an incentive.
-message IncentiveClaim {
-  // Reward granted.
-  Reward reward = 1;
-  // Claim time in UTC seconds.
-  int64 claim_time_sec = 2;
-}
-
-// An incentive set up by a user.
-message Incentive {
-  // The ID of the incentive.
-  string id = 1;
-  // Name.
-  string name = 2;
-  // Description.
-  string description = 3;
-  // Shareable incentive code.
-  string code = 4;
-  // The type of the incentive.
-  IncentiveType type = 5;
-  // Create time in UTC seconds.
-  int64 create_time_sec = 6;
-  // Update time in UTC seconds.
-  int64 update_time_sec = 7;
-  // Expiry time in UTC seconds.
-  int64 expiry_time_sec = 8;
-  // Available reward.
-  AvailableRewards recipient_rewards = 9;
-  // Sender reward.
-  AvailableRewards sender_rewards = 10;
-  // Recipient user IDs for which the owner of the incentive has not yet claimed their sender reward.
-  repeated string unclaimed_recipients = 11;
-  // Sender rewards so far collected for this incentive.
-  repeated Reward rewards = 12;
-  // Max claims.
-  int64 max_claims = 13;
-  // Current user IDs that have claimed, and their outcomes.
-  map<string, IncentiveClaim> claims = 14;
-}
-
-// A list of incentives set up by a user.
-message IncentiveList {
-  // Incentives set up by a single user.
-  repeated Incentive incentives = 1;
-}
-
-// An incentive claimant's view of a single incentive.
-message IncentiveInfo {
-  // The ID of the incentive.
-  string id = 1;
-  // Name.
-  string name = 2;
-  // Description.
-  string description = 3;
-  // Unique shareable incentive code.
-  string code = 4;
-  // The type of the incentive.
-  IncentiveType type = 5;
-  // Incentive sender user ID.
-  string sender = 6;
-  // Available rewards that the caller can claim.
-  AvailableRewards available_rewards = 7;
-  // Indicator if the caller can claim rewards.
-  bool can_claim = 8;
-  // Reward that was granted.
-  Reward reward = 9;
-  // Create time in UTC seconds.
-  int64 create_time_sec = 10;
-  // Update time in UTC seconds.
-  int64 update_time_sec = 11;
-  // Expiry time in UTC seconds.
-  int64 expiry_time_sec = 12;
-  // Claim time in UTC seconds.
-  int64 claim_time_sec = 13;
-}
-
-// Request by a user to set up a new incentive.
-message IncentiveSenderCreateRequest {
-  // The incentive configuration ID.
-  string id = 1;
-}
-
-// Request by a user to delete an incentive they had set up.
-message IncentiveSenderDeleteRequest {
-  // The unique incentive code.
-  string code = 1;
-}
-
-// Request by a user to claim rewards from an incentive they had set up.
-message IncentiveSenderClaimRequest {
-  // The unique incentive code.
-  string code = 1;
-  // The recipient ID(s) to claim for, or empty for all.
-  repeated string recipient_ids = 2;
-}
-
-// Request by a potential incentive claimant to view incentive information.
-message IncentiveRecipientGetRequest {
-  // The unique incentive code.
-  string code = 1;
-}
-
-// Request by a potential incentive claimant to claim an incentive.
-message IncentiveRecipientClaimRequest {
-  // The unique incentive code.
-  string code = 1;
-}
-
 // The cost(s) associated with permanently unlocking a progression.
 message ProgressionCost {
   // The items which will be deducted.
@@ -675,6 +559,121 @@ message AvailableRewards {
   int64 total_weight = 4;
 }
 
+// Types of incentives.
+enum IncentiveType {
+  // Unspecified. Defaults to INVITE.
+  INCENTIVE_TYPE_UNSPECIFIED = 0;
+  // An invite with an associated incentive reward.
+  INCENTIVE_TYPE_INVITE = 1;
+}
+
+// The result of claiming an incentive.
+message IncentiveClaim {
+  // Reward granted.
+  Reward reward = 1;
+  // Claim time in UTC seconds.
+  int64 claim_time_sec = 2;
+}
+
+// An incentive set up by a user.
+message Incentive {
+  // The ID of the incentive.
+  string id = 1;
+  // Name.
+  string name = 2;
+  // Description.
+  string description = 3;
+  // Shareable incentive code.
+  string code = 4;
+  // The type of the incentive.
+  IncentiveType type = 5;
+  // Create time in UTC seconds.
+  int64 create_time_sec = 6;
+  // Update time in UTC seconds.
+  int64 update_time_sec = 7;
+  // Expiry time in UTC seconds.
+  int64 expiry_time_sec = 8;
+  // Available reward.
+  AvailableRewards recipient_rewards = 9;
+  // Sender reward.
+  AvailableRewards sender_rewards = 10;
+  // Recipient user IDs for which the owner of the incentive has not yet claimed their sender reward.
+  repeated string unclaimed_recipients = 11;
+  // Sender rewards so far collected for this incentive.
+  repeated Reward rewards = 12;
+  // Max claims.
+  int64 max_claims = 13;
+  // Current user IDs that have claimed, and their outcomes.
+  map<string, IncentiveClaim> claims = 14;
+}
+
+// A list of incentives set up by a user.
+message IncentiveList {
+  // Incentives set up by a single user.
+  repeated Incentive incentives = 1;
+}
+
+// An incentive claimant's view of a single incentive.
+message IncentiveInfo {
+  // The ID of the incentive.
+  string id = 1;
+  // Name.
+  string name = 2;
+  // Description.
+  string description = 3;
+  // Unique shareable incentive code.
+  string code = 4;
+  // The type of the incentive.
+  IncentiveType type = 5;
+  // Incentive sender user ID.
+  string sender = 6;
+  // Available rewards that the caller can claim.
+  AvailableRewards available_rewards = 7;
+  // Indicator if the caller can claim rewards.
+  bool can_claim = 8;
+  // Reward that was granted.
+  Reward reward = 9;
+  // Create time in UTC seconds.
+  int64 create_time_sec = 10;
+  // Update time in UTC seconds.
+  int64 update_time_sec = 11;
+  // Expiry time in UTC seconds.
+  int64 expiry_time_sec = 12;
+  // Claim time in UTC seconds.
+  int64 claim_time_sec = 13;
+}
+
+// Request by a user to set up a new incentive.
+message IncentiveSenderCreateRequest {
+  // The incentive configuration ID.
+  string id = 1;
+}
+
+// Request by a user to delete an incentive they had set up.
+message IncentiveSenderDeleteRequest {
+  // The unique incentive code.
+  string code = 1;
+}
+
+// Request by a user to claim rewards from an incentive they had set up.
+message IncentiveSenderClaimRequest {
+  // The unique incentive code.
+  string code = 1;
+  // The recipient ID(s) to claim for, or empty for all.
+  repeated string recipient_ids = 2;
+}
+
+// Request by a potential incentive claimant to view incentive information.
+message IncentiveRecipientGetRequest {
+  // The unique incentive code.
+  string code = 1;
+}
+
+// Request by a potential incentive claimant to claim an incentive.
+message IncentiveRecipientClaimRequest {
+  // The unique incentive code.
+  string code = 1;
+}
 
 // Find and retrieve an event leaderboard by ID, automatically joining the event if necessary.
 message EventLeaderboardGet {


### PR DESCRIPTION
Another .proto reorder.

The Unreal codegen requires messages to be defined before other messages that depend on them.

Codegen fix is a tricky one so we've landed on just maintaining the .proto this way for now.