### PR TITLE
fix(economy): missing max_count property declaration

### DIFF
--- a/schemas/09-Hiro-Economy.json
+++ b/schemas/09-Hiro-Economy.json
@@ -75,6 +75,11 @@
               "title": "name",
               "pattern": ".{1,}"
             },
+            "max_count": {
+              "type": "number",
+              "title": "max_count",
+              "minimum": 0
+            },
             "recipient_reward": {
               "$ref": "Hiro-Rewards"
             },


### PR DESCRIPTION
Property as marked as required but it wasn't defined.
<img width="654" alt="Screenshot 2024-05-15 at 16 50 04" src="https://github.com/heroiclabs/hiro/assets/6062267/69720f23-02dc-41da-a558-9283d1fd4ce1">
