### PR TITLE
Update 16-Hiro-Auctions.json

### DIFF
--- a/schemas/16-Hiro-Auctions.json
+++ b/schemas/16-Hiro-Auctions.json
@@ -121,7 +121,8 @@
                   ],
                   "type": "object"
                 }
-              }
+              },
+              "type": "object"
             }
           },
           "required": [


### PR DESCRIPTION
The `type:object` removed earlier was actually declared at the wrong level of the json schema.