### PR TITLE
Sync JSON schemas with Go config struct definitions

### DIFF
--- a/schemas/01-Hiro-Reward.json
+++ b/schemas/01-Hiro-Reward.json
@@ -81,9 +81,32 @@
           },
           "operator": {
             "enum": [
-              "infinite"
+              "infinite",
+              "set_refill_count",
+              "set_refill_sec",
+              "set_max_count"
             ],
             "type": "string"
+          },
+          "value": {
+            "properties": {
+              "max": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "min": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "multiple": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "min"
+            ],
+            "type": "object"
           }
         },
         "required": [

--- a/schemas/01-Hiro-Reward.json
+++ b/schemas/01-Hiro-Reward.json
@@ -8,15 +8,15 @@
           "properties": {
             "max": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "min": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "multiple": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "required": [
@@ -33,15 +33,15 @@
           "properties": {
             "max": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "min": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "multiple": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "required": [
@@ -59,15 +59,15 @@
             "properties": {
               "max": {
                 "minimum": 0,
-                "type": "number"
+                "type": "integer"
               },
               "min": {
                 "minimum": 0,
-                "type": "number"
+                "type": "integer"
               },
               "multiple": {
                 "minimum": 0,
-                "type": "number"
+                "type": "integer"
               }
             },
             "required": [
@@ -100,19 +100,19 @@
         "properties": {
           "max": {
             "minimum": 0,
-            "type": "number"
+            "type": "integer"
           },
           "max_repeats": {
             "minimum": 0,
-            "type": "number"
+            "type": "integer"
           },
           "min": {
             "minimum": 0,
-            "type": "number"
+            "type": "integer"
           },
           "multiple": {
             "minimum": 0,
-            "type": "number"
+            "type": "integer"
           },
           "set": {
             "items": {
@@ -136,15 +136,15 @@
           "properties": {
             "max": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "min": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "multiple": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "numeric_properties": {
               "patternProperties": {
@@ -178,7 +178,7 @@
                           "properties": {
                             "weight": {
                               "minimum": 0,
-                              "type": "number"
+                              "type": "integer"
                             }
                           }
                         }
@@ -187,7 +187,7 @@
                     },
                     "total_weight": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     }
                   }
                 }
@@ -210,15 +210,15 @@
             "properties": {
               "max": {
                 "minimum": 0,
-                "type": "number"
+                "type": "integer"
               },
               "min": {
                 "minimum": 0,
-                "type": "number"
+                "type": "integer"
               },
               "multiple": {
                 "minimum": 0,
-                "type": "number"
+                "type": "integer"
               }
             },
             "required": [
@@ -248,15 +248,15 @@
             "properties": {
               "max": {
                 "minimum": 0,
-                "type": "number"
+                "type": "integer"
               },
               "min": {
                 "minimum": 0,
-                "type": "number"
+                "type": "integer"
               },
               "multiple": {
                 "minimum": 0,
-                "type": "number"
+                "type": "integer"
               }
             },
             "required": [
@@ -278,7 +278,7 @@
     },
     "weight": {
       "minimum": 0,
-      "type": "number"
+      "type": "integer"
     }
   },
   "type": "object"

--- a/schemas/02-Hiro-Rewards.json
+++ b/schemas/02-Hiro-Rewards.json
@@ -77,6 +77,9 @@
                 "$ref": "Hiro-Reward"
               },
               "type": "array"
+            },
+            "to_mailbox_expiry_sec": {
+              "type": "integer"
             }
           },
           "type": "object"

--- a/schemas/02-Hiro-Rewards.json
+++ b/schemas/02-Hiro-Rewards.json
@@ -7,15 +7,15 @@
     },
     "max_repeat_rolls": {
       "minimum": 0,
-      "type": "number"
+      "type": "integer"
     },
     "max_rolls": {
       "minimum": 0,
-      "type": "number"
+      "type": "integer"
     },
     "total_weight": {
       "minimum": 0,
-      "type": "number"
+      "type": "integer"
     },
     "weighted": {
       "items": {
@@ -24,7 +24,10 @@
       "type": "array"
     },
     "to_mailbox_expiry_sec": {
-      "type": "number"
+      "type": "integer"
+    },
+    "message": {
+      "type": "string"
     },
     "team_reward": {
       "properties": {
@@ -33,15 +36,15 @@
         },
         "max_repeat_rolls": {
           "minimum": 0,
-          "type": "number"
+          "type": "integer"
         },
         "max_rolls": {
           "minimum": 0,
-          "type": "number"
+          "type": "integer"
         },
         "total_weight": {
           "minimum": 0,
-          "type": "number"
+          "type": "integer"
         },
         "weighted": {
           "items": {
@@ -50,7 +53,7 @@
           "type": "array"
         },
         "to_mailbox_expiry_sec": {
-          "type": "number"
+          "type": "integer"
         },
         "member_reward": {
           "properties": {
@@ -59,15 +62,15 @@
             },
             "max_repeat_rolls": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "max_rolls": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "total_weight": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "weighted": {
               "items": {

--- a/schemas/03-Hiro-Base.json
+++ b/schemas/03-Hiro-Base.json
@@ -29,7 +29,7 @@
     "rate_app_smtp_port": {
       "maximum": 65535,
       "minimum": 1,
-      "type": "number"
+      "type": "integer"
     },
     "rate_app_smtp_username": {
       "pattern": ".{1,}",

--- a/schemas/04-Hiro-Tutorials.json
+++ b/schemas/04-Hiro-Tutorials.json
@@ -16,11 +16,11 @@
             },
             "max_step": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "start_step": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "type": "object"

--- a/schemas/05-Hiro-Teams.json
+++ b/schemas/05-Hiro-Teams.json
@@ -144,7 +144,24 @@
         },
         "limits": {
           "type": "object",
-          "description": "InventoryConfigLimits - definition not provided"
+          "properties": {
+            "categories": {
+              "patternProperties": {
+                ".+": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "item_sets": {
+              "patternProperties": {
+                ".+": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            }
+          }
         }
       }
     },

--- a/schemas/05-Hiro-Teams.json
+++ b/schemas/05-Hiro-Teams.json
@@ -523,9 +523,6 @@
       "properties": {
         "max_size": {
           "type": "integer"
-        },
-        "expiry_sec": {
-          "type": "integer"
         }
       }
     },

--- a/schemas/05-Hiro-Teams.json
+++ b/schemas/05-Hiro-Teams.json
@@ -11,6 +11,9 @@
       "type": "integer",
       "minimum": 1
     },
+    "allow_multiple_teams": {
+      "type": "boolean"
+    },
     "wallet": {
       "$ref": "#/$defs/TeamsWalletConfig"
     },
@@ -242,6 +245,9 @@
         "duration_sec": {
           "type": "integer"
         },
+        "time_offset_sec": {
+          "type": "integer"
+        },
         "max_count": {
           "type": "integer"
         },
@@ -297,6 +303,9 @@
           "type": "string"
         },
         "duration_sec": {
+          "type": "integer"
+        },
+        "time_offset_sec": {
           "type": "integer"
         },
         "max_count": {
@@ -403,6 +412,24 @@
         },
         "duration": {
           "type": "integer"
+        },
+        "max_rolls": {
+          "type": "integer"
+        },
+        "score_target": {
+          "type": "integer"
+        },
+        "score_target_players": {
+          "type": "integer"
+        },
+        "score_time_limit_sec": {
+          "type": "integer"
+        },
+        "tier_delta_per_phase": {
+          "type": "integer"
+        },
+        "roll_cooldown_sec": {
+          "type": "integer"
         }
       }
     },
@@ -410,7 +437,28 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
         "cohort_size": {
+          "type": "integer"
+        },
+        "max_num_score": {
+          "type": "integer"
+        },
+        "score_target": {
+          "type": "integer"
+        },
+        "score_target_players": {
+          "type": "integer"
+        },
+        "score_time_limit_sec": {
+          "type": "integer"
+        },
+        "tier_delta_per_phase": {
           "type": "integer"
         }
       }
@@ -433,6 +481,12 @@
         },
         "tier_change": {
           "type": "integer"
+        },
+        "roll_cooldown_sec": {
+          "type": "integer"
+        },
+        "reroll_count_freeze": {
+          "type": "boolean"
         }
       }
     },
@@ -450,6 +504,15 @@
           "type": "boolean"
         },
         "use_max_cohort_size": {
+          "type": "boolean"
+        },
+        "promotion_reroll_count_freeze": {
+          "type": "boolean"
+        },
+        "demotion_reroll_count_freeze": {
+          "type": "boolean"
+        },
+        "nochange_reroll_count_freeze": {
           "type": "boolean"
         }
       }

--- a/schemas/05-Hiro-Teams.json
+++ b/schemas/05-Hiro-Teams.json
@@ -148,6 +148,7 @@
             "categories": {
               "patternProperties": {
                 ".+": {
+                  "minimum": 0,
                   "type": "integer"
                 }
               },
@@ -156,6 +157,7 @@
             "item_sets": {
               "patternProperties": {
                 ".+": {
+                  "minimum": 0,
                   "type": "integer"
                 }
               },

--- a/schemas/07-Hiro-Inventory.json
+++ b/schemas/07-Hiro-Inventory.json
@@ -35,7 +35,7 @@
             },
             "max_count": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "name": {
               "pattern": ".{1,}",
@@ -76,7 +76,7 @@
           "patternProperties": {
             ".+": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "type": "object"
@@ -85,7 +85,7 @@
           "patternProperties": {
             ".+": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "type": "object"

--- a/schemas/08-Hiro-Energy.json
+++ b/schemas/08-Hiro-Energy.json
@@ -19,26 +19,26 @@
             },
             "max_count": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "max_overfill": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "refill_count": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "refill_time_sec": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "reward": {
               "$ref": "Hiro-Rewards"
             },
             "start_count": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "required": [

--- a/schemas/09-Hiro-Economy.json
+++ b/schemas/09-Hiro-Economy.json
@@ -23,7 +23,7 @@
                   "patternProperties": {
                     ".{1,}": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     }
                   },
                   "type": "object"
@@ -32,7 +32,7 @@
                   "patternProperties": {
                     ".{1,}": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     }
                   },
                   "type": "object"
@@ -42,7 +42,7 @@
             },
             "count": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "description": {
               "pattern": ".*",
@@ -50,7 +50,7 @@
             },
             "max_count": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "name": {
               "pattern": ".{1,}",
@@ -61,7 +61,7 @@
             },
             "user_contribution_max_count": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "required": [
@@ -79,7 +79,7 @@
           "patternProperties": {
             ".{1,}": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "type": "object"
@@ -88,7 +88,7 @@
           "patternProperties": {
             ".{1,}": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "type": "object"
@@ -139,7 +139,7 @@
                   "patternProperties": {
                     ".{1,}": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     }
                   },
                   "type": "object"

--- a/schemas/09-Hiro-Economy.json
+++ b/schemas/09-Hiro-Economy.json
@@ -48,6 +48,10 @@
               "pattern": ".*",
               "type": "string"
             },
+            "duration_sec": {
+              "minimum": 0,
+              "type": "integer"
+            },
             "max_count": {
               "minimum": 0,
               "type": "integer"

--- a/schemas/10-Hiro-Achievements.json
+++ b/schemas/10-Hiro-Achievements.json
@@ -29,7 +29,7 @@
             },
             "count": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "description": {
               "pattern": ".*",
@@ -37,19 +37,23 @@
             },
             "duration_sec": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "start_time_sec": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "end_time_sec": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
+            },
+            "time_offset_sec": {
+              "minimum": 0,
+              "type": "integer"
             },
             "max_count": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "name": {
               "pattern": ".{1,}",
@@ -93,7 +97,7 @@
                     },
                     "count": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     },
                     "description": {
                       "pattern": ".*",
@@ -101,11 +105,15 @@
                     },
                     "duration_sec": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
+                    },
+                    "time_offset_sec": {
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "max_count": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     },
                     "name": {
                       "pattern": ".{1,}",

--- a/schemas/11-Hiro-Unlockables.json
+++ b/schemas/11-Hiro-Unlockables.json
@@ -4,15 +4,15 @@
   "properties": {
     "active_slots": {
       "minimum": 0,
-      "type": "number"
+      "type": "integer"
     },
     "max_active_slots": {
       "minimum": 0,
-      "type": "number"
+      "type": "integer"
     },
     "max_queued_unlocks": {
       "minimum": 0,
-      "type": "number"
+      "type": "integer"
     },
     "slot_cost": {
       "properties": {
@@ -20,7 +20,7 @@
           "patternProperties": {
             ".{1,}": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "type": "object"
@@ -29,7 +29,7 @@
           "patternProperties": {
             ".{1,}": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "type": "object"
@@ -39,7 +39,7 @@
     },
     "slots": {
       "minimum": 0,
-      "type": "number"
+      "type": "integer"
     },
     "unlockables": {
       "patternProperties": {
@@ -63,7 +63,7 @@
                   "patternProperties": {
                     ".{1,}": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     }
                   },
                   "type": "object"
@@ -72,7 +72,7 @@
                   "patternProperties": {
                     ".{1,}": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     }
                   },
                   "type": "object"
@@ -82,7 +82,7 @@
             },
             "cost_unit_time_sec": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "description": {
               "pattern": ".*",
@@ -94,7 +94,7 @@
             },
             "probability": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "reward": {
               "$ref": "Hiro-Rewards"
@@ -105,7 +105,7 @@
                   "patternProperties": {
                     ".{1,}": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     }
                   },
                   "type": "object"
@@ -114,7 +114,7 @@
                   "patternProperties": {
                     ".{1,}": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     }
                   },
                   "type": "object"
@@ -124,7 +124,7 @@
             },
             "wait_time_sec": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             }
           },
           "required": [

--- a/schemas/12-Hiro-Event-Leaderboards.json
+++ b/schemas/12-Hiro-Event-Leaderboards.json
@@ -38,6 +38,15 @@
                     },
                     "use_max_cohort_size": {
                       "type": "boolean"
+                    },
+                    "promotion_reroll_count_freeze": {
+                      "type": "boolean"
+                    },
+                    "demotion_reroll_count_freeze": {
+                      "type": "boolean"
+                    },
+                    "nochange_reroll_count_freeze": {
+                      "type": "boolean"
                     }
                   },
                   "type": "object"
@@ -47,7 +56,7 @@
             },
             "cohort_size": {
               "minimum": 1,
-              "type": "number"
+              "type": "integer"
             },
             "description": {
               "pattern": ".*",
@@ -55,19 +64,43 @@
             },
             "duration": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
+            },
+            "max_rolls": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "score_target": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "score_target_players": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "score_time_limit_sec": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tier_delta_per_phase": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "roll_cooldown_sec": {
+              "minimum": 0,
+              "type": "integer"
             },
             "end_time_sec": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "max_idle_tier_drop": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "max_num_score": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "name": {
               "pattern": ".+",
@@ -97,17 +130,24 @@
                       },
                       "rank_max": {
                         "minimum": 0,
-                        "type": "number"
+                        "type": "integer"
                       },
                       "rank_min": {
                         "minimum": 0,
-                        "type": "number"
+                        "type": "integer"
                       },
                       "reward": {
                         "$ref": "Hiro-Rewards"
                       },
                       "tier_change": {
-                        "type": "number"
+                        "type": "integer"
+                      },
+                      "roll_cooldown_sec": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "reroll_count_freeze": {
+                        "type": "boolean"
                       }
                     },
                     "type": "object"
@@ -119,15 +159,41 @@
             },
             "start_time_sec": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "tier_overrides": {
               "patternProperties": {
                 "[0-9]+": {
                   "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
                     "cohort_size": {
                       "minimum": 1,
-                      "type": "number"
+                      "type": "integer"
+                    },
+                    "max_num_score": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "score_target": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "score_target_players": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "score_time_limit_sec": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "tier_delta_per_phase": {
+                      "minimum": 0,
+                      "type": "integer"
                     }
                   },
                   "type": "object"
@@ -137,7 +203,7 @@
             },
             "tiers": {
               "minimum": 1,
-              "type": "number"
+              "type": "integer"
             }
           },
           "type": "object"

--- a/schemas/14-Hiro-Progressions.json
+++ b/schemas/14-Hiro-Progressions.json
@@ -156,6 +156,9 @@
             "unconditional_updates": {
               "type": "boolean"
             },
+            "reset_schedule": {
+              "type": "string"
+            },
             "preconditions": {
               "$ref": "#/definitions/ProgressionPreconditionsBlock"
             }

--- a/schemas/16-Hiro-Auctions.json
+++ b/schemas/16-Hiro-Auctions.json
@@ -20,20 +20,24 @@
                 "type": "string"
               }
             },
+            "bid_history_count": {
+              "minimum": 0,
+              "type": "integer"
+            },
             "conditions": {
               "patternProperties": {
                 ".+": {
                   "properties": {
                     "duration_sec": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     },
                     "listing_cost": {
                       "properties": {
                         "currencies": {
                           "patternProperties": {
                             ".+": {
-                              "type": "number"
+                              "type": "integer"
                             }
                           },
                           "type": "object"
@@ -41,7 +45,7 @@
                         "items": {
                           "patternProperties": {
                             ".+": {
-                              "type": "number"
+                              "type": "integer"
                             }
                           },
                           "type": "object"
@@ -49,7 +53,7 @@
                         "energies": {
                           "patternProperties": {
                             ".+": {
-                              "type": "number"
+                              "type": "integer"
                             }
                           },
                           "type": "object"
@@ -62,7 +66,7 @@
                         "currencies": {
                           "patternProperties": {
                             ".+": {
-                              "type": "number"
+                              "type": "integer"
                             }
                           },
                           "type": "object"
@@ -78,7 +82,7 @@
                         "fixed": {
                           "patternProperties": {
                             ".+": {
-                              "type": "number"
+                              "type": "integer"
                             }
                           },
                           "type": "object"
@@ -88,15 +92,15 @@
                     },
                     "extension_threshold_sec": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     },
                     "extension_sec": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     },
                     "extension_max_sec": {
                       "minimum": 0,
-                      "type": "number"
+                      "type": "integer"
                     },
                     "fee": {
                       "properties": {
@@ -106,7 +110,7 @@
                         "fixed": {
                           "patternProperties": {
                             ".+": {
-                              "type": "number"
+                              "type": "integer"
                             }
                           },
                           "type": "object"

--- a/schemas/16-Hiro-Auctions.json
+++ b/schemas/16-Hiro-Auctions.json
@@ -80,9 +80,14 @@
                           "type": "number"
                         },
                         "fixed": {
-                          "patternProperties": {
-                            ".+": {
-                              "type": "integer"
+                          "properties": {
+                            "currencies": {
+                              "patternProperties": {
+                                ".+": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
                             }
                           },
                           "type": "object"
@@ -108,9 +113,14 @@
                           "type": "number"
                         },
                         "fixed": {
-                          "patternProperties": {
-                            ".+": {
-                              "type": "integer"
+                          "properties": {
+                            "currencies": {
+                              "patternProperties": {
+                                ".+": {
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object"
                             }
                           },
                           "type": "object"

--- a/schemas/17-Hiro-Streaks.json
+++ b/schemas/17-Hiro-Streaks.json
@@ -5,11 +5,11 @@
     "Hiro-StreakReward": {
       "properties": {
         "count_min": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0
         },
         "count_max": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0
         },
         "reward": {
@@ -35,27 +35,31 @@
               "pattern": ".*"
             },
             "count": {
-              "type": "number",
+              "type": "integer",
               "minimum": 0
             },
             "max_count": {
-              "type": "number",
+              "type": "integer",
               "minimum": 0
             },
             "max_count_current_reset": {
-              "type": "number",
+              "type": "integer",
               "minimum": 0
             },
             "idle_count_decay_reset": {
-              "type": "number",
+              "type": "integer",
               "minimum": 0
             },
             "max_idle_count_decay": {
-              "type": "number",
+              "type": "integer",
               "minimum": 0
             },
             "reset_cronexpr": {
               "type": "string"
+            },
+            "time_offset_sec": {
+              "type": "integer",
+              "minimum": 0
             },
             "rewards": {
               "type": "array",
@@ -64,11 +68,11 @@
               }
             },
             "start_time_sec": {
-              "type": "number",
+              "type": "integer",
               "minimum": 0
             },
             "end_time_sec": {
-              "type": "number",
+              "type": "integer",
               "minimum": 0
             },
             "disabled": {

--- a/schemas/18-Hiro-Challenges.json
+++ b/schemas/18-Hiro-Challenges.json
@@ -7,24 +7,24 @@
         ".+": {
           "properties": {
             "reward_tiers": {
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "rank_max": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "rank_min": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "reward": {
-                  "$ref": "Hiro-Rewards"
-                }
-              },
+              "type": "array",
               "minItems": 1,
-              "type": "array"
+              "items": {
+                "type": "object",
+                "properties": {
+                  "rank_max": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "rank_min": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "reward": {
+                    "$ref": "Hiro-Rewards"
+                  }
+                }
+              }
             },
             "additional_properties": {
               "patternProperties": {
@@ -36,11 +36,11 @@
             },
             "max_num_score": {
               "minimum": 1,
-              "type": "number"
+              "type": "integer"
             },
             "start_delay_max_sec": {
               "minimum": 0,
-              "type": "number"
+              "type": "integer"
             },
             "ascending": {
               "type": "boolean"
@@ -60,11 +60,11 @@
               "properties": {
                 "min_sec": {
                   "minimum": 0,
-                  "type": "number"
+                  "type": "integer"
                 },
                 "max_sec": {
                   "minimum": 0,
-                  "type": "number"
+                  "type": "integer"
                 }
               },
               "type": "object"
@@ -73,11 +73,11 @@
               "properties": {
                 "min": {
                   "minimum": 1,
-                  "type": "number"
+                  "type": "integer"
                 },
                 "max": {
                   "minimum": 1,
-                  "type": "number"
+                  "type": "integer"
                 }
               },
               "type": "object"


### PR DESCRIPTION
- Add ~20 missing fields across schemas to match current Go structs, including Event Leaderboards 2.0 fields, change zone reroll flags, time offsets, and progression reset schedules
- Remove stale `expiry_sec` field from Teams `TeamRewardMailboxConfig` that no longer exists in Go
- Normalize `"type": "number"` to `"type": "integer"` across 12 schema files where Go types are int/int64, keeping `"number"` only for float64 fields