### PR TITLE
Add economy ReapplyInitializeUser function [HIRO-85]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [keep a changelog](http://keepachangelog.com) and this pr
 :warning: This server code is versioned separately to the download of the [Hiro game framework](https://heroiclabs.com/hiro/). :warning:
 
 ## [Unreleased]
+### Added
+- Add new economy "ReapplyInitializeUser" function to apply new initialize_user config currencies and items to an existing user.
+
 ### Changed
 - Support forward compatibility with definitions in Storage and Satori personalizers.
 

--- a/economy.go
+++ b/economy.go
@@ -286,6 +286,9 @@ type EconomySystem interface {
 	// SetAllowFakeReceipts sets whether fake receipts are allowed for testing purposes. This function replaces the existing AllowFakeReceipts setting in EconomyConfig.
 	SetAllowFakeReceipts(allow bool)
 
+	// ReapplyInitializeUser reapplies the initialize user configuration for a given userID. It only applies new currencies and inventory items. This can be used to retroactively apply changes to the initialize user configuration.
+	ReapplyInitializeUser(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, userID string) error
+
 	// SetOnDonationClaimReward sets a custom reward function which will run after a donation's reward is rolled.
 	SetOnDonationClaimReward(fn OnReward[*EconomyConfigDonation])
 

--- a/events_satori.go
+++ b/events_satori.go
@@ -43,6 +43,7 @@ const (
 	EventSourceUnlockableSlotPurchased   = "unlockableSlotPurchased"
 	EventSourceUnlockableClaimed         = "unlockableClaimed"
 	EventSourceInitializeUser            = "initializeUser"
+	EventSourceReapplyInitializeUser     = "reapplyInitializeUser"
 	EventSourceChallengeClaimed          = "challengeClaimed"
 )
 


### PR DESCRIPTION
Allows to apply changes introduced in initialize_user to an existing account.
Only currencies that the user has not owned, and items he does not currently hold are granted.
